### PR TITLE
Disable `mix-blend-mode` in `br-loyalty-card-body`.

### DIFF
--- a/main.less
+++ b/main.less
@@ -327,7 +327,7 @@ dl.br-credential-card-attr > dd {
   height: 100%;
   width: 100%;
   justify-content: center;
-  mix-blend-mode: overlay;
+  // mix-blend-mode: overlay;
 }
 .br-loyalty-card-body > img {
   flex: 0 1 auto;


### PR DESCRIPTION
Putting this here as a reminder that the less/css in the master branch does not work properly, at least in some cases.

The loyalty card classes are used by the identity card template as well.